### PR TITLE
Find the deepest child.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 mod process_tree;
 
 use std::{
+    ffi::OsString,
     io::{stdout, Write},
     path::PathBuf,
 };
@@ -22,19 +23,22 @@ fn get_path() -> ProcResult<PathBuf> {
     t.into_deepest_leaf().map(|proc| proc.into_cwd())
 }
 
-fn main() -> std::io::Result<()> {
-    let path = match get_path() {
-        Ok(path) => path.into(),
-        Err(error) => {
-            eprintln!("Could not get cwd: {error}");
-            if let Some(home) = std::env::var_os("HOME") {
-                home
-            } else {
-                eprintln!("HOME not set");
-                "/".into()
-            }
-        }
+fn get_path_with_fallbacks() -> OsString {
+    match get_path() {
+        Ok(path) => return path.into(),
+        Err(error) => eprintln!("Could not get cwd: {error}"),
     };
+
+    match std::env::var_os("HOME") {
+        Some(home) => return home,
+        None => eprintln!("HOME not set"),
+    }
+
+    "/".into()
+}
+
+fn main() -> std::io::Result<()> {
+    let path = get_path_with_fallbacks();
     stdout().write_all(path.as_encoded_bytes())?;
     println!();
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn get_path() -> ProcResult<PathBuf> {
             .parse()?,
     )?;
 
-    t.into_deepest_leaf().map(Into::into)
+    t.into_deepest_leaf().map(|proc| proc.into_cwd())
 }
 
 fn main() -> std::io::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,94 +1,41 @@
 // SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
+mod process_tree;
 
 use std::{
-    error::Error,
-    ffi::OsStr,
     io::{stdout, Write},
     path::PathBuf,
 };
 
-#[derive(Debug)]
-struct Process {
-    cwd: PathBuf,
-    tty: i32,
-}
+use process_tree::ProcessTree;
+use procfs::ProcResult;
 
-#[derive(Debug)]
-struct ProcessTree {
-    node: Process,
-    children: Vec<ProcessTree>,
-}
-
-impl ProcessTree {
-    fn new(pid: u32) -> Result<ProcessTree, Box<dyn Error>> {
-        let p = procfs::process::Process::new(pid as i32)?;
-        let node = Process {
-            cwd: p.cwd()?,
-            tty: p.stat()?.tty_nr,
-        };
-
-        let t = p.task_main_thread()?;
-        let c_pids = t.children()?;
-        let children = c_pids
-            .into_iter()
-            .map(ProcessTree::new)
-            .collect::<Result<_, _>>()?;
-
-        Ok(ProcessTree { node, children })
-    }
-
-    fn leaf_nodes_with_tty(&self) -> Vec<&Process> {
-        let leaves: Vec<&Process> = self
-            .children
-            .iter()
-            .flat_map(|c| c.leaf_nodes_with_tty())
-            .collect();
-
-        if !leaves.is_empty() {
-            return leaves;
-        }
-
-        if self.node.tty != 0 {
-            vec![&self.node]
-        } else {
-            vec![]
-        }
-    }
-}
-
-fn print_path<T: AsRef<OsStr>>(path: T) -> std::io::Result<()> {
-    stdout().write_all(path.as_ref().as_encoded_bytes())?;
-    println!();
-    Ok(())
-}
-
-fn get_path() -> Result<PathBuf, Box<dyn Error>> {
+fn get_path() -> ProcResult<PathBuf> {
     let t = ProcessTree::new(
         std::env::args()
             .nth(1)
             .ok_or("First argument is required.")?
             .parse()?,
     )?;
-    let leafs = t.leaf_nodes_with_tty();
 
-    let first_leaf = leafs.first().ok_or("Could not get first leaf node")?;
-
-    Ok(first_leaf.cwd.clone())
+    t.into_deepest_leaf().map(Into::into)
 }
 
 fn main() -> std::io::Result<()> {
-    match get_path() {
-        Ok(path) => print_path(path),
+    let path = match get_path() {
+        Ok(path) => path.into(),
         Err(error) => {
             eprintln!("Could not get cwd: {error}");
             if let Some(home) = std::env::var_os("HOME") {
-                print_path(home)
+                home
             } else {
                 eprintln!("HOME not set");
-                print_path("/")
+                "/".into()
             }
         }
-    }
+    };
+    stdout().write_all(path.as_encoded_bytes())?;
+    println!();
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn get_path() -> ProcResult<PathBuf> {
     let t = ProcessTree::new(
         std::env::args()
             .nth(1)
-            .ok_or("First argument is required.")?
+            .ok_or("First argument is required")?
             .parse()?,
     )?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
+// SPDX-FileCopyrightText: 2025 Joshix <joshix@asozial.org>
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
+
 mod process_tree;
 
 use std::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,8 +85,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         eprintln!("Could not get cwd: {error}");
         if let Some(home) = std::env::var_os("HOME") {
             print_path(home);
+            Ok(())
+        } else {
+            Err("HOME not set".into())
         }
+    } else {
+        Ok(())
     }
-
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,11 @@ use std::{
     path::PathBuf,
 };
 
-use process_tree::ProcessTree;
+use process_tree::Process;
 use procfs::ProcResult;
 
 fn get_path() -> ProcResult<PathBuf> {
-    let t = ProcessTree::new(
+    let t = Process::new(
         std::env::args()
             .nth(1)
             .ok_or("First argument is required")?

--- a/src/process_tree.rs
+++ b/src/process_tree.rs
@@ -78,10 +78,10 @@ impl Process {
             .map(|(_, r)| r.is_ok())
             .unwrap_or(false);
         // query the cwd of self
-        let cwd_child: ProcResult<CwdProcess> = self.try_into();
-        if cwd_child.is_ok() || !max_is_ok {
+        let cwd: ProcResult<_> = self.try_into();
+        if cwd.is_ok() || !max_is_ok {
             // could read cwd or max wasn't ok
-            *deapest_leaf = Some((depth, cwd_child));
+            *deapest_leaf = Some((depth, cwd));
         }
     }
 

--- a/src/process_tree.rs
+++ b/src/process_tree.rs
@@ -12,6 +12,12 @@ pub struct CwdProcessTree {
     cwd: PathBuf,
 }
 
+impl CwdProcessTree {
+    pub fn into_cwd(self) -> PathBuf {
+        self.cwd
+    }
+}
+
 #[derive(Debug)]
 pub struct ProcessTree {
     proc: Process,
@@ -83,12 +89,6 @@ impl Deref for CwdProcessTree {
 
     fn deref(&self) -> &Self::Target {
         &self.tree
-    }
-}
-
-impl From<CwdProcessTree> for PathBuf {
-    fn from(value: CwdProcessTree) -> Self {
-        value.cwd
     }
 }
 

--- a/src/process_tree.rs
+++ b/src/process_tree.rs
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{ops::Deref, path::PathBuf};
+
+use procfs::{
+    process::{Process, Task},
+    ProcError, ProcResult,
+};
+
+#[derive(Debug)]
+pub struct CwdProcessTree {
+    tree: ProcessTree,
+    cwd: PathBuf,
+}
+
+#[derive(Debug)]
+pub struct ProcessTree {
+    proc: Process,
+    task: Task,
+}
+
+impl ProcessTree {
+    pub fn new(pid: u32) -> ProcResult<ProcessTree> {
+        let proc = Process::new(pid as i32)?;
+
+        let task = proc.task_main_thread()?;
+
+        Ok(ProcessTree { proc, task })
+    }
+
+    fn children(&self) -> ProcResult<impl IntoIterator<Item = ProcResult<ProcessTree>>> {
+        Ok(self.task.children()?.into_iter().map(ProcessTree::new))
+    }
+
+    pub fn into_deepest_leaf(self) -> ProcResult<CwdProcessTree> {
+        fn deepest_leaf(depth: usize, tree: ProcessTree) -> (usize, ProcResult<CwdProcessTree>) {
+            let children = tree.children();
+            let mut max: Option<(usize, ProcResult<CwdProcessTree>)> = None;
+            match children {
+                Ok(children) => {
+                    for child in children {
+                        match child {
+                            Ok(child) => {
+                                let leaf = deepest_leaf(depth + 1, child);
+                                match leaf.1.as_ref() {
+                                    Ok(_) => match max.as_ref() {
+                                        Some(value) => {
+                                            if value.0 < leaf.0 {
+                                                max = Some(leaf);
+                                            }
+                                        }
+                                        None => max = Some(leaf),
+                                    },
+                                    Err(err) => eprintln!("Could not go deeper: {err}"),
+                                }
+                            }
+                            Err(err) => eprintln!("Could not get child: {err}"),
+                        }
+                    }
+                }
+                Err(err) => eprintln!("Could not get children: {err}"),
+            }
+
+            match max {
+                Some(max) => max,
+                None => (depth, tree.try_into()),
+            }
+        }
+
+        deepest_leaf(0, self).1
+    }
+}
+
+impl From<CwdProcessTree> for ProcessTree {
+    fn from(value: CwdProcessTree) -> Self {
+        value.tree
+    }
+}
+
+impl Deref for CwdProcessTree {
+    type Target = ProcessTree;
+
+    fn deref(&self) -> &Self::Target {
+        &self.tree
+    }
+}
+
+impl From<CwdProcessTree> for PathBuf {
+    fn from(value: CwdProcessTree) -> Self {
+        value.cwd
+    }
+}
+
+impl TryFrom<ProcessTree> for CwdProcessTree {
+    type Error = ProcError;
+
+    fn try_from(tree: ProcessTree) -> Result<Self, Self::Error> {
+        let cwd = tree.proc.cwd()?;
+        Ok(CwdProcessTree { cwd, tree })
+    }
+}

--- a/src/process_tree.rs
+++ b/src/process_tree.rs
@@ -39,15 +39,6 @@ impl Process {
         Ok(Process { proc })
     }
 
-    fn children(&self) -> ProcResult<impl IntoIterator<Item = ProcResult<Process>>> {
-        Ok(self
-            .proc
-            .task_main_thread()?
-            .children()?
-            .into_iter()
-            .map(Process::new))
-    }
-
     pub fn is_tty(&self) -> bool {
         match self.proc.stat() {
             Ok(stat) => stat.tty_nr != 0,
@@ -56,32 +47,49 @@ impl Process {
     }
 
     #[inline]
-    fn check_children(
+    fn add_children_to_stack(
+        &self,
+        depth: usize,
+        stack: &mut Vec<(usize, ProcResult<Process>)>,
+    ) -> ProcResult<()> {
+        for task in self.tasks()? {
+            stack.extend(
+                task?
+                    .children()?
+                    .into_iter()
+                    .map(|pid| (depth, Process::new(pid))),
+            );
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    fn find_deepest_leaf(
         self,
         depth: usize,
         stack: &mut Vec<(usize, ProcResult<Process>)>,
-        deapest_leaf: &mut Option<(usize, ProcResult<CwdProcess>)>,
+        deepest_leaf: &mut Option<(usize, ProcResult<CwdProcess>)>,
     ) {
         if !self.is_tty() {
             // this can happen when forking of a terminal
             // e.g. some random deeply-nested gcc process
             // we only want to get cwds of procs with tty
-            eprintln!("Ignoring process {} (not tty)", self.proc.pid());
+            eprintln!("Ignoring process {} (not tty)", self.pid());
             return;
         }
         // add the children to the stack
-        match self.children() {
-            Ok(children) => stack.extend(children.into_iter().map(|proc| (depth + 1, proc))),
-            Err(err) => eprintln!("Could not go deeper: {err}"),
+        if let Err(err) = self.add_children_to_stack(depth + 1, stack) {
+            eprintln!("Error while getting children of {}: {err}", self.pid());
         }
         // the current maximum depth
-        let max_depth = deapest_leaf.as_ref().map(|(d, _)| *d).unwrap_or(0);
+        let max_depth = deepest_leaf.as_ref().map(|(d, _)| *d).unwrap_or(0);
         if depth <= max_depth {
             // depth isn't greater than max_depth
             // self is not a leaf, can be ignored
             return;
         }
-        let max_is_ok = deapest_leaf
+        let max_is_ok = deepest_leaf
             .as_ref()
             .map(|(_, r)| r.is_ok())
             .unwrap_or(false);
@@ -90,30 +98,28 @@ impl Process {
         let cwd: ProcResult<_> = self.try_into();
         if cwd.is_ok() || !max_is_ok {
             // could read cwd or max wasn't ok
-            *deapest_leaf = Some((depth, cwd));
+            *deepest_leaf = Some((depth, cwd));
         }
     }
 
     pub fn into_deepest_leaf(self) -> ProcResult<CwdProcess> {
-        let mut stack: Vec<(usize, ProcResult<Process>)> = match self.children() {
-            Ok(children) => children.into_iter().map(|proc| (1, proc)).collect(),
-            Err(error) => {
-                eprintln!("Could not get children: {error}");
-                // return self as we couldn't get the children
-                return self.try_into();
-            }
+        let mut stack: Vec<(usize, ProcResult<Process>)> = vec![];
+        if let Err(error) = self.add_children_to_stack(1, &mut stack) {
+            eprintln!("Could not get children: {error}");
+            // return self as we couldn't get the children
+            return self.try_into();
         };
         // the cwd of the process with the maximum depth
-        let mut deapest_leaf: Option<(usize, ProcResult<CwdProcess>)> = None;
+        let mut deepest_leaf: Option<(usize, ProcResult<CwdProcess>)> = None;
         // loop over all the children in the stack
         while let Some((depth, child)) = stack.pop() {
             match child {
-                Ok(child) => child.check_children(depth, &mut stack, &mut deapest_leaf),
+                Ok(child) => child.find_deepest_leaf(depth, &mut stack, &mut deepest_leaf),
                 Err(err) => eprintln!("Could not get child: {err}"),
             }
         }
         // return the cwd ProcResult with the maximum depth or fallback to self
-        deapest_leaf
+        deepest_leaf
             .map(|(_, cwd_result)| cwd_result)
             .unwrap_or_else(|| self.try_into())
     }

--- a/src/process_tree.rs
+++ b/src/process_tree.rs
@@ -16,6 +16,16 @@ impl CwdProcess {
     pub fn into_cwd(self) -> PathBuf {
         self.cwd
     }
+
+    #[allow(dead_code)]
+    pub fn cwd(&self) -> &PathBuf {
+        &self.cwd
+    }
+
+    #[allow(dead_code)]
+    pub fn process(&self) -> &Process {
+        &self.proc
+    }
 }
 
 pub struct Process {
@@ -120,14 +130,6 @@ impl Deref for Process {
 impl From<CwdProcess> for Process {
     fn from(value: CwdProcess) -> Self {
         value.proc
-    }
-}
-
-impl Deref for CwdProcess {
-    type Target = Process;
-
-    fn deref(&self) -> &Self::Target {
-        &self.proc
     }
 }
 

--- a/src/process_tree.rs
+++ b/src/process_tree.rs
@@ -7,7 +7,6 @@ use std::{ops::Deref, path::PathBuf};
 
 use procfs::{process, ProcError, ProcResult};
 
-#[derive(Debug)]
 pub struct CwdProcess {
     proc: Process,
     cwd: PathBuf,
@@ -19,7 +18,6 @@ impl CwdProcess {
     }
 }
 
-#[derive(Debug)]
 pub struct Process {
     proc: process::Process,
 }
@@ -77,6 +75,7 @@ impl Process {
             .as_ref()
             .map(|(_, r)| r.is_ok())
             .unwrap_or(false);
+
         // query the cwd of self
         let cwd: ProcResult<_> = self.try_into();
         if cwd.is_ok() || !max_is_ok {

--- a/src/process_tree.rs
+++ b/src/process_tree.rs
@@ -58,8 +58,8 @@ impl Process {
                                 let (depth, leaf) = deepest_leaf(depth + 1, child);
                                 match leaf.as_ref() {
                                     Ok(proc) if proc.is_tty() => match max.as_ref() {
-                                        Some((max_depth, _)) => {
-                                            if *max_depth < depth {
+                                        Some((max_depth, saved)) => {
+                                            if *max_depth <= depth || saved.is_err() {
                                                 max = Some((depth, leaf));
                                             }
                                         }
@@ -87,7 +87,9 @@ impl Process {
             }
         }
 
-        deepest_leaf(0, self).1
+        let (_, result) = deepest_leaf(0, self);
+
+        result
     }
 }
 

--- a/src/process_tree.rs
+++ b/src/process_tree.rs
@@ -109,6 +109,14 @@ impl Process {
     }
 }
 
+impl Deref for Process {
+    type Target = process::Process;
+
+    fn deref(&self) -> &Self::Target {
+        &self.proc
+    }
+}
+
 impl From<CwdProcess> for Process {
     fn from(value: CwdProcess) -> Self {
         value.proc

--- a/src/process_tree.rs
+++ b/src/process_tree.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
+// SPDX-FileCopyrightText: 2025 Joshix <joshix@asozial.org>
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
I've noticed a few problems:
1. It doesn't use the deepest child process (xcwd claims to do that) (dunno if/when that makes a difference)
2. If the first leaf process is a root-process trying to read the cwd fails (permission error)

This pr should fix that by finding the deepest child process that has a readable cwd.  
Reading all processes and their cwds at the start made fixing the second problem hard. That's why I decided to do that lazily.   
I also removed some cwd() calls which could make this a tiny bit faster, but that doesn't really matter.

  
    
    
    
Sorry for refactoring everything